### PR TITLE
typed-css-modules从0.5.0版本开始改用TS开发,增加对此情况的支持

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ async function renderScss(code: string) {
 
 async function renderTypedFile(css: string) {
   const DtsCreator = requireg('typed-css-modules');
-  let creator = new DtsCreator();
+  let creator = DtsCreator.hasOwnProperty('default') ? new DtsCreator.default() : new DtsCreator();
   const content = await creator.create('', css);
   const typedCode = content.formatted;
   return typedCode as string;


### PR DESCRIPTION
相关issue: #4 