### PR TITLE
Fix extension and add Stylus support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,10 @@ All notable changes to the "typed-css-modules-plugin" extension will be document
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.2.4]
+- Fix extension not working
+- Add support for Stylus (.styl)
+- Catch eslint check
+
+## [0.2.3]
 - Initial release

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![logo](./logo.png)
 
-Creates .d.ts files from css-modules .css/.less/.scss files
+Creates .d.ts files from css-modules .css/.less/.scss/.styl files
 
 ## Install
 
@@ -17,6 +17,9 @@ npm install less
 
 # if you need scss
 npm install node-sass
+
+# if you need sylus
+npm install stylus
 ```
 
 Modules can be installed globally. `yarn` is supported.
@@ -37,7 +40,7 @@ or
 /* @type */
 ```
 
-ahead of your `.css/.less/.scss` file, and save, you will get a `d.ts` file in same directory.
+ahead of your `.css/.less/.scss/.styl` file, and save, you will get a `d.ts` file in same directory.
 
 ## preview
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "typed-css-modules-plugin",
   "icon": "logo.png",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "MIT",
   "displayName": "CSS Module Typed",
   "description": "Creates .d.ts files from css-modules .css/.less/.scss files",
   "author": "xcodebuild <me@xcodebuild.com>",
   "contributors": [
-    "Ignat Awwit <ignatius.awwit@gmail.com>"
+    "Ignat Awwit <ignatius.awwit@gmail.com>",
+    "Daniel Clausmeyer <daniel@shwao.com>"
   ],
   "publisher": "awwit",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ function requireg<T>(packageName: string, required = true): T | null {
 let less: any = null
 
 async function renderLess(code: string): Promise<string> {
-  if (less === undefined) {
+  if (less === null) {
     less = requireg('less')
   }
 
@@ -63,7 +63,7 @@ async function renderLess(code: string): Promise<string> {
 let sass: any = null
 
 function renderScss(code: string): string {
-  if (sass === undefined) {
+  if (sass === null) {
     sass = requireg('node-sass')
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,9 +129,11 @@ function renderTypedFile(css: string, filePath: string): Promise<Buffer> {
 
   return dtsCreator.create('', css).then(function ({ formatted }) {
     if (eslintEngine !== null) {
-      const report = eslintEngine.executeOnText(formatted, filePath)
-
-      return Buffer.from(report.results[0].output || formatted, 'utf-8')
+      try {
+        const report = eslintEngine.executeOnText(formatted, filePath);
+        if(report.results[0])
+          formatted = report.results[0].output as string;
+      } catch(error) {}
     }
 
     return Buffer.from(formatted, 'utf-8')


### PR DESCRIPTION
Great extension but there was a bug. In `src/extension.ts` on line 50 and 63 you set `less` and `sass` to null and then you do `if (less === undefined)` and `if (sass === undefined)` which can not work. I changed both lines to check for `null` instead of `undefined`.

I also added support for [Stylus lang](https://stylus-lang.com)

I do not know about your style or version conventions, feel free to change it. If you dont like my name in the package.json feel free to remove it.